### PR TITLE
feat: add undefined check for server data in duplicate deletion dialog

### DIFF
--- a/duplicate_deletion_dialog.html
+++ b/duplicate_deletion_dialog.html
@@ -202,8 +202,9 @@
         try {
           // Server-side safely emits a JavaScript object literal (no parsing needed)
           // Using <?!= ?> force-print scriptlet with JSON.stringify() for safe injection
+          // The ?? null ensures we always get valid JavaScript even if data is undefined
           // Note: The scriptlet syntax below will cause linter errors but is valid Google Apps Script template syntax
-          data = <?!= JSON.stringify(data) ?>;
+          data = <?!= JSON.stringify(typeof data !== 'undefined' ? data : null) ?>;
         } catch (e) {
           throw new Error('No data received from server: ' + e.message);
         }


### PR DESCRIPTION
Add a safety check to ensure valid JavaScript is generated even when the server-side `data` variable is undefined. This prevents potential runtime errors by defaulting to `null` when data is not available, using a ternary operator with typeof check before JSON stringification.

The change improves error handling in the template scriptlet injection process and ensures the client-side code always receives valid JavaScript.